### PR TITLE
Rotate HUD (right click menu) with canvas (map)

### DIFF
--- a/lockview.js
+++ b/lockview.js
@@ -239,6 +239,17 @@ async function onRenderSidebarTab(){
   sendViewBox();
 }
 
+function waitForHudToRender() {
+  return new Promise(resolve => {
+    const interval = setInterval(() => {
+      if (canvas.hud.rendered) {
+        clearInterval(interval);
+        resolve();
+      }
+    }, 100);
+  });
+}
+
 function forceInitialView() {
   if (newSceneLoad) return canvas.scene.initial;
   else return {};
@@ -255,7 +266,15 @@ export async function applySettings(force=false,forceInitial=true) {
   //Get the flags for this scene
   await getFlags();
 
-  if (rotation != null) canvas.stage.rotation = rotation*Math.PI/180;
+  if (rotation != null) {
+    let rotationRadians = rotation*Math.PI/180
+    canvas.stage.rotation = rotationRadians
+    // The first time the canvas is rendered, the hud may not exist yet
+    // so don't try to rotate hud until it has rendered
+    waitForHudToRender().then(() => {
+      canvas.hud._element[0].style.rotate = `${rotationRadians}rad`
+    })
+  };
 
   //If 'autoScale' if 'horizontal fit', 'vertical fit' or 'automatic fit'
   if (autoScale > 0 && autoScale < 5 && force) 

--- a/src/socket.js
+++ b/src/socket.js
@@ -31,7 +31,11 @@ async function resetView(payload){
     let newPosition = canvas.scene.initial;
     if (newPosition == null) newPosition = canvas.scene._viewPosition;
     
-    if (payload.rotateSett != "null") canvas.stage.rotation = payload.rotateSett*Math.PI/180;
+    if (payload.rotateSett != "null") {
+      let rotationRadians = payload.rotateSett*Math.PI/180;
+      canvas.stage.rotation = rotationRadians
+      canvas.hud._element[0].style.rotate = `${rotationRadians}rad`
+    };
     if (payload.scaleSett == 0) newPosition.scale = canvas.scene._viewPosition.scale;
     else if (payload.scaleSett == 1) newPosition.scale = payload.scale;
     else if (payload.scaleSett == 3){
@@ -145,7 +149,11 @@ async function newView(payload){
     let scale;
     let position = canvas.scene._viewPosition;
 
-    if (payload.rotateSett > 0) canvas.stage.rotation = payload.rotateSett*Math.PI/180;
+    if (payload.rotateSett > 0) {
+      let rotationRadians = payload.rotateSett*Math.PI/180;
+      canvas.stage.rotation = rotationRadians
+      canvas.hud._element[0].style.rotate = `${rotationRadians}rad`
+    };
 
     if (payload.scaleSett == 0) position.scale = canvas.scene._viewPosition.scale;
     else {


### PR DESCRIPTION
The HUD is a separate DOM element (a traditional `<div>`) that isn't connected to the `<canvas>` that renders the scene. Before, only the canvas was rotated, leaving all hud elements behind, usually off screen. Now, the hud element is given the same rotation as the canvas to place is correctly.

Note: Unlike the element that renders the scene, the hud is a classic html div, which means there isn't an easy property to set to rotate it. There are two ways to find the hud, either the way I've done it, or to find it by it's id `#hud`. I've opted to go through the `canvas` object that is used everywhere else, but I honestly don't know if there's a better way to do this.

Also note the `waitForHudToRender()` function. This exists because the canvas may render before the hud. Since this calls the `canvasReady` hook which eventually calls `applySettings()`, it's possible the hud doesn't yet exist and isn't ready to rotate. In order to rotate the hud, we must wait for it to render. This does not hold up the rest of the function, and after the initial render there is no delay

Please let me know if there's any tweaks or improvements I can make, I'm still very new to Foundry addon development

Fixes https://github.com/MaterialFoundry/LockView/issues/103