### PR TITLE
Added setting to make the module Isometric Perspective work properly

### DIFF
--- a/src/sceneConfig.js
+++ b/src/sceneConfig.js
@@ -77,6 +77,7 @@ export async function renderSceneConfig(app,html){
             <option value=90 ${flags.rotation==90 ? "selected" : ""}>${rotationOptions[1]}</option>
             <option value=180 ${flags.rotation==180 ? "selected" : ""}>${rotationOptions[2]}</option>
             <option value=270 ${flags.rotation==270 ? "selected" : ""}>${rotationOptions[3]}</option>
+            <option value=330 ${flags.rotation==330 ? "selected" : ""}>${rotationOptions[4]}</option>
             </select>
         <p class="notes">${game.i18n.localize("LockView.Scene.Rotation_Hint")}</p>
     </div>

--- a/src/settings.js
+++ b/src/settings.js
@@ -286,7 +286,8 @@ export class SceneConfigurator extends FormApplication {
         {label: game.i18n.localize("LockView.Scene.Rotation.Landscape_Short"), value:'0', selected:''},
         {label: game.i18n.localize("LockView.Scene.Rotation.Portrait_Short"), value:'90', selected:''},
         {label: game.i18n.localize("LockView.Scene.Rotation.FlippedLandscape_Short"), value:'180', selected:''},
-        {label: game.i18n.localize("LockView.Scene.Rotation.FlippedPortrait_Short"), value:'270', selected:''}
+        {label: game.i18n.localize("LockView.Scene.Rotation.FlippedPortrait_Short"), value:'270', selected:''},
+        {label: "Isometric View", value: '330', selected: ''}
       ];
       
       if (i == game.scenes.size) {


### PR DESCRIPTION
I added this line in modules/LockView/src/settings.js:
{label: "Isometric View", value: '330', selected: ''}
---
I added this line in modules/LockView/src/sceneConfig.js:
<option value=330 ${flags.rotation==330 ? "selected" : ""}>${rotationOptions[4]}</option>
