### PR TITLE
Fix typo "Colapse" -> "Collapse"

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -189,7 +189,7 @@
                 "Expand": "Expand"
             },
             "ExpandToSeeMore": "Expand to see more.",
-            "CollapseExpandAll": "Colapse or Expand All",
+            "CollapseExpandAll": "Collapse or Expand All",
             "Collapse": "Collapse",
             "Expand": "Expand",
             "LockViewHelp": "Lock View Help"


### PR DESCRIPTION
"Colapse" -> "Collapse" for "CollapseExpandAll" entry in en.json